### PR TITLE
fix "gunicorn error 104 Connection reset by peer"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Script==0.6.6
 Flask-Babel==0.9
 toml==0.8.2
 PyYAML==3.10
-gunicorn==18.0
+gunicorn==19.1.1
 lever==0.2.6
 redis==2.10.3
 six==1.6.1


### PR DESCRIPTION
I often encounter https://github.com/benoitc/gunicorn/issues/630, and update gunicorn to 19.1.1 can solve this error.
